### PR TITLE
Fix: handle Brium's empty entries sum response

### DIFF
--- a/spec/brium_api_spec.cr
+++ b/spec/brium_api_spec.cr
@@ -17,6 +17,26 @@ describe Brium::API do
     keyword.budget.should eq(5678)
   end
 
+  it "parses entries/sum.json response" do
+    WebMock.stub(:get, "https://brium.me/api/entries/sum.json")
+      .with(
+        headers: {"Host" => "brium.me", "Authorization" => "Bearer some_token"},
+        query: {"record" => "some-great-project"}
+      ).to_return(body: "1072.95")
+    api = Brium::API.new("some_token")
+    api.entries_sum(record: "some-great-project").should eq(1072.95)
+  end
+
+  it "parses an empty entries/sum.json response" do
+    WebMock.stub(:get, "https://brium.me/api/entries/sum.json")
+      .with(
+        headers: {"Host" => "brium.me", "Authorization" => "Bearer some_token"},
+        query: {"record" => "non-existent-project"}
+      ).to_return(body: "")
+    api = Brium::API.new("some_token")
+    api.entries_sum(record: "non-existent-project").should eq(0)
+  end
+
   it "compiles" do
     typeof(begin
       client_id = "..."

--- a/src/brium/api.cr
+++ b/src/brium/api.cr
@@ -53,6 +53,7 @@ class Brium::API
                   until_date = nil)
     params = entries_filter(client, project, worker, billable_status, record, since_date, until_date)
     response = get "/api/entries/sum.json?#{params}"
+    return 0.0 if response.body.empty?
     response.body.to_f
   end
 


### PR DESCRIPTION
Brium's `/api/entries/sum.json` endpoint returns an empty body (instead of a 0) when there are no entries to sum.

So `Brium::API#entries_sum` was raising while trying to convert an empty string to Float.

See manastech/citta#212